### PR TITLE
XML parser is unset to avoid memory leaks

### DIFF
--- a/lib/class.soap_parser.php
+++ b/lib/class.soap_parser.php
@@ -137,6 +137,7 @@ class nusoap_parser extends nusoap_base {
 				}
 			}
 			xml_parser_free($this->parser);
+			unset($this->parser);
 		} else {
 			$this->debug('xml was empty, didn\'t parse!');
 			$this->setError('xml was empty, didn\'t parse!');

--- a/lib/class.wsdl.php
+++ b/lib/class.wsdl.php
@@ -280,6 +280,7 @@ class wsdl extends nusoap_base {
         } 
 		// free the parser
         xml_parser_free($this->parser);
+		unset($this->parser);
         $this->debug('Parsing WSDL done');
 		// catch wsdl parse errors
 		if($this->getError()){

--- a/lib/class.xmlschema.php
+++ b/lib/class.xmlschema.php
@@ -144,6 +144,7 @@ class nusoap_xmlschema extends nusoap_base  {
 	    	}
             
 			xml_parser_free($this->parser);
+			unset($this->parser);
 		} else{
 			$this->debug('no xml passed to parseString()!!');
 			$this->setError('no xml passed to parseString()!!');


### PR DESCRIPTION
Unsets parser to avoid memory leaks (in PHP 7+):
http://php.net/manual/en/function.xml-set-object.php:
In addition to calling xml_parser_free() when the parsing is finished, as of PHP 7.0.0 it is necessary to also explicitly unset the reference to parser to avoid memory leaks.
