### PR TITLE
Safer change for missing property

### DIFF
--- a/lib/class.soapclient.php
+++ b/lib/class.soapclient.php
@@ -514,7 +514,7 @@ class nusoap_client extends nusoap_base  {
 			$this->xml_encoding = 'ISO-8859-1';
 		}
 		$this->debug('Use encoding: ' . $this->xml_encoding . ' when creating nusoap_parser');
-		$parser = new nusoap_parser($data,$this->xml_encoding,$this->operations,$this->decode_utf8);
+		$parser = new nusoap_parser($data,$this->xml_encoding,property_exists($this, 'operation') ? $this->operation : '',$this->decode_utf8);
 		// add parser debug data to our debug
 		$this->appendDebug($parser->getDebug());
 		// if parse errors


### PR DESCRIPTION
Property exists check and default to empty string to keep data type consistent as string
